### PR TITLE
Mods to integrate accuracy computation into scale-up workflow

### DIFF
--- a/src/dswx_sar/compute_acc_with_hls.py
+++ b/src/dswx_sar/compute_acc_with_hls.py
@@ -406,7 +406,8 @@ def download_dswx_hls(polys,
                     download_file = f'{download_folder}/{dswx_hls_filename}'
 
                     if not os.path.isfile(download_file):
-                        response = requests.get(dswx_hls_url, stream=True)
+                        response = requests.get(dswx_hls_url, stream=True,
+                                                headers={"Authorization": f"Bearer {ebt}"})
 
                     # Check if the request was successful
                         if response.status_code == 200:

--- a/src/dswx_sar/compute_acc_with_hls.py
+++ b/src/dswx_sar/compute_acc_with_hls.py
@@ -15,7 +15,7 @@ import shapely
 from shapely.geometry import LinearRing, Point, Polygon, box
 import rasterio
 import requests
-import dswx_sar_util
+from dswx_sar import dswx_sar_util
 
 def createParser():
     parser = argparse.ArgumentParser(
@@ -25,6 +25,10 @@ def createParser():
                         help='initial input file')
     parser.add_argument('-o', '--outputdir', dest='output_dir', type=str, required=True,
                         help='initial input file')
+    parser.add_argument('-t', '--ebt', dest='ebt', type=str,
+                        default='',
+                        help='EDL bearer token (EBT)')
+
     return parser
 
 def extract_metadata(geotiff_path):
@@ -357,7 +361,8 @@ def download_dswx_hls(polys,
                       datetime_end_str, 
                       MGRS_tile,
                       download_folder,
-                      download_flag=True):
+                      download_flag=True,
+                      ebt=''):
     CMR_OPS = 'https://cmr.earthdata.nasa.gov/search'
     url = f'{CMR_OPS}/{"granules"}'
     boundind_box = polys.bounds
@@ -367,11 +372,15 @@ def download_dswx_hls(polys,
                     'provider': provider,
                     'bounding_box': f'{boundind_box[1]+0.2},{boundind_box[0]+0.2},{boundind_box[3]-0.2},{boundind_box[2]-0.2}',
                     'page_size': 200,}
+
+    # Set up the header for the GET request
+    request_headers = {'Accept': 'application/json'}
+    if ebt:
+        request_headers['Authorization'] = f"Bearer {ebt}"
+
     response = requests.get(url,
                             params=parameters,
-                            headers={
-                                'Accept': 'application/json'
-                            }
+                            headers=request_headers
                         )
     print('DSWX-HLS found : ', response.headers['CMR-Hits'])
     downloaded_list = []
@@ -474,7 +483,8 @@ def run(cfg):
                                   datetime_end_str,
                                   MGRS_tile_id,
                                   download_folder='DSWx-HLS',
-                                  download_flag=True)
+                                  download_flag=True,
+                                  ebt=cfg.ebt)
             if num_data:
                 for dswx_hls_file in dswx_hls_list:
                     valid_test = False

--- a/src/dswx_sar/compute_acc_with_hls.py
+++ b/src/dswx_sar/compute_acc_with_hls.py
@@ -406,8 +406,9 @@ def download_dswx_hls(polys,
                     download_file = f'{download_folder}/{dswx_hls_filename}'
 
                     if not os.path.isfile(download_file):
+                        download_req_header = {"Authorization": f"Bearer {ebt}"} if ebt else None
                         response = requests.get(dswx_hls_url, stream=True,
-                                                headers={"Authorization": f"Bearer {ebt}"})
+                                                headers=download_req_header)
 
                     # Check if the request was successful
                         if response.status_code == 200:

--- a/src/dswx_sar/dswx_s1.py
+++ b/src/dswx_sar/dswx_s1.py
@@ -75,8 +75,8 @@ def dswx_s1_workflow(cfg):
     save_mgrs_tiles.run(cfg)
 
     # compute accuracy
-    cmdline = f'compute_acc_with_hls.py -i {cfg.groups.product_path_group.sas_output_path} -o {cfg.groups.product_path_group.sas_output_path}'
-    os.system(cmdline)
+    #cmdline = f'compute_acc_with_hls.py -i {cfg.groups.product_path_group.sas_output_path} -o {cfg.groups.product_path_group.sas_output_path}'
+    #os.system(cmdline)
 
     t_time_end = time.time()
     logger.info(f'total processing time: {t_time_end - t_all} sec')


### PR DESCRIPTION
This PR is to add changes to integrate the accuracy computations to the AWS scale-up workflow. The highlights of the changes are:

- add `--ebt` option to `compute_acc_with_hls.py` to provide EBT when querying to CMR
- Suppress running `compute_acc_with_hls.py` inside `dswx_s1.py` for convenience in passing the credential (i.e. EBT)
- A minor fix for importing a module.